### PR TITLE
ML Pipeline Setup: Preprocessing + CNN Model Implementations

### DIFF
--- a/ml_models/base_cnn_model.py
+++ b/ml_models/base_cnn_model.py
@@ -1,0 +1,44 @@
+"""
+ml_models/base_cnn_model.py
+
+Define + train a basic CNN classifier from scratch (w/o any pretrained skeleton).
+We save the trained weights to `baseline_model.h5`.
+"""
+
+import tensorflow as tf
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Conv2D, MaxPooling2D, Flatten, Dense, Dropout
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+
+def build_baseline_model(num_classes=5):
+    model = Sequential([
+        Conv2D(32, (3, 3), activation='relu', input_shape=(224, 224, 3)),
+        MaxPooling2D((2, 2)),
+
+        Conv2D(64, (3, 3), activation='relu'),
+        MaxPooling2D((2, 2)),
+
+        Conv2D(128, (3, 3), activation='relu'),
+        MaxPooling2D((2, 2)),
+
+        Flatten(),
+        Dropout(0.5),
+        Dense(128, activation='relu'),
+        Dense(num_classes, activation='softmax')
+    ])
+    
+    model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
+    return model
+
+def train_baseline_model(train_dir, val_dir, model_save_path="baseline_model.h5", num_classes=5, epochs=5):
+    datagen = ImageDataGenerator(rescale=1./255)
+    train_gen = datagen.flow_from_directory(train_dir, target_size=(224, 224), class_mode='categorical')
+    val_gen = datagen.flow_from_directory(val_dir, target_size=(224, 224), class_mode='categorical')
+
+    model = build_baseline_model(num_classes)
+    model.fit(train_gen, validation_data=val_gen, epochs=epochs)
+    model.save(model_save_path)
+    return model
+
+if __name__ == "__main__":
+    print("In order to train this baseline CNN, call train_baseline_model(train_dir, val_dir)")

--- a/ml_models/classify_compare.py
+++ b/ml_models/classify_compare.py
@@ -1,0 +1,36 @@
+import os
+import numpy as np
+from tensorflow.keras.models import load_model
+from ml_utils.preprocessing import load_and_preprocess_image
+from vision import get_image_labels
+
+CLASS_NAMES = ["UI", "Ad", "Game", "Error", "Text"]
+
+def classify_with_model(image_path, model_path='trained_model.h5'):
+    model = load_model(model_path)
+    image = load_and_preprocess_image(image_path)
+    image = np.expand_dims(image, axis=0)
+    preds = model.predict(image)
+    predicted_class = np.argmax(preds, axis=1)[0]
+    return CLASS_NAMES[predicted_class]
+
+def classify_with_vision_api(image_path):
+    try:
+        labels = get_image_labels(image_path)
+        return labels  # returns top 5 labels, less if fewer found
+    except Exception as e:
+        return [f"Error: {str(e)}"]
+
+def compare_outputs(folder_path):
+    for filename in os.listdir(folder_path):
+        if filename.lower().endswith((".png", ".jpg", ".jpeg")):
+            path = os.path.join(folder_path, filename)
+            cnn_label = classify_with_model(path)
+            vision_labels = classify_with_vision_api(path)
+            print(f"\n📷 {filename}")
+            print(f"CNN Prediction: {cnn_label}")
+            print(f"Vision API Labels: {vision_labels}")
+
+if __name__ == "__main__":
+    compare_outputs("test")
+    # compare_outputs("uploaded_screenshots")

--- a/ml_models/efficientnet_cnn.py
+++ b/ml_models/efficientnet_cnn.py
@@ -1,0 +1,36 @@
+"""
+ml_models/cnn_model.py
+
+Define + train a CNN classifier w/ EfficientNetB0.
+saving to `trained_model.h5`.
+"""
+
+import tensorflow as tf
+from tensorflow.keras.applications import EfficientNetB0
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, GlobalAveragePooling2D, Dropout
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+
+def build_model(num_classes=5):
+    base_model = EfficientNetB0(include_top=False, input_shape=(224, 224, 3), weights='imagenet')
+    base_model.trainable = False
+
+    x = base_model.output
+    x = GlobalAveragePooling2D()(x)
+    x = Dropout(0.4)(x)
+    x = Dense(256, activation='relu')(x)
+    output = Dense(num_classes, activation='softmax')(x)
+
+    model = Model(inputs=base_model.input, outputs=output)
+    model.compile(optimizer='adam', loss='categorical_crossentropy', metrics=['accuracy'])
+    return model
+
+def train_model(train_dir, val_dir, model_save_path="trained_model.h5", num_classes=5, epochs=3):
+    datagen = ImageDataGenerator(rescale=1./255)
+    train_gen = datagen.flow_from_directory(train_dir, target_size=(224, 224), class_mode='categorical')
+    val_gen = datagen.flow_from_directory(val_dir, target_size=(224, 224), class_mode='categorical')
+
+    model = build_model(num_classes)
+    model.fit(train_gen, validation_data=val_gen, epochs=epochs)
+    model.save(model_save_path)
+    return model

--- a/ml_utils/preprocessing.py
+++ b/ml_utils/preprocessing.py
@@ -1,0 +1,45 @@
+"""
+ml_utils/preprocessing.py
+
+Image preprocessing for the CNN pipeline:
+- Resizing
+- Denoising
+- Edge detection
+- Normalization
+
+call / apply script on both `test/` and `uploaded_screenshots/` folders depending on step -->
+"""
+
+import cv2
+import numpy as np
+import os
+
+def resize_image(image, size=(224, 224)):
+    return cv2.resize(image, size)
+
+def denoise_image(image):
+    return cv2.fastNlMeansDenoisingColored(image, None, 10, 10, 7, 21)
+
+def detect_edges(image):
+    return cv2.Canny(image, 100, 200)
+
+def normalize_image(image):
+    return image.astype("float32") / 255.0
+
+def load_and_preprocess_image(path):
+    image = cv2.imread(path)
+    image = resize_image(image)
+    image = denoise_image(image)
+    image = normalize_image(image)
+    return image
+
+def preprocess_folder(folder_path):
+    print(f"processing the images in: {folder_path}")
+    for filename in os.listdir(folder_path):
+        if filename.lower().endswith((".png", ".jpg", ".jpeg")):
+            img_path = os.path.join(folder_path, filename)
+            image = cv2.imread(img_path)
+            resized = resize_image(image)
+            denoised = denoise_image(resized)
+            edges = detect_edges(resized)
+            print(f"processed image {filename}")


### PR DESCRIPTION
### 
Introducing the core machine learning pipeline created for screenshot classification (ended up opting for Google Vision API overall).

- (1) `ml_utils/preprocessing.py`: Implements image resizing, denoising, normalization, and edge detection for consistent input to CNN 
- (2) `ml_models/baseline_cnn_model.py`: Defines a simple, trainable convolutional neural network from scratch
- (3) `ml_models/cnn_model.py`: Defines a transfer learning pipeline using EfficientNetB0 with frozen weights and a custom classifier head, able to train and save

Comprised our experimentation with the ML component of this project before we compared results with and transitioned to the Vision API solution
